### PR TITLE
Use Crambda Runtime

### DIFF
--- a/spec/serverless/lambda/http_request_spec.cr
+++ b/spec/serverless/lambda/http_request_spec.cr
@@ -5,6 +5,7 @@ describe SLS::Lambda::HTTPRequest do
     ENV["_HANDLER"] = "foo"
     input = JSON.parse(request_body)
     req = SLS::Lambda::HTTPRequest.new(input)
+
     req.method.should eq "POST"
     req.path.should eq "/hello"
     req.headers["User-Agent"].should eq "curl/7.54.0"
@@ -28,12 +29,21 @@ describe SLS::Lambda::HTTPRequest do
   end
 
   it "supports JSON serialization/deserialization" do
-    body = %q({ "path" : "/test", "httpMethod" : "GET", "headers" : { "key": "value" }, "requestContext" : {} })
     ENV["_HANDLER"] = "my_handler"
+    body = %q({
+      "path" : "/test",
+      "httpMethod" : "GET",
+      "headers" : {
+        "key": "value"
+      },
+      "requestContext" : {}
+    })
+
     input = JSON.parse body
     req = SLS::Lambda::HTTPRequest.new(input)
     json = req.to_json
     parsed_req = SLS::Lambda::HTTPRequest.from_json json.to_s
+
     req.headers.should eq parsed_req.headers
     req.to_json.should eq parsed_req.to_json
     req.method.should eq parsed_req.method

--- a/spec/serverless/lambda/http_response_spec.cr
+++ b/spec/serverless/lambda/http_response_spec.cr
@@ -2,34 +2,45 @@ require "../../spec_helper"
 
 describe SLS::Lambda::HTTPResponse do
   it "always returns status code" do
-    json = JSON.parse SLS::Lambda::HTTPResponse.new(123).to_json
+    res = SLS::Lambda::HTTPResponse.new
+    res.status_code = 123
+
+    json = JSON.parse res.to_json
     json["statusCode"].as_i.should eq 123
-    json["body"]?.should be_nil
+    json["body"]?.should eq ""
   end
 
   it "can contain a body as text" do
+    res = SLS::Lambda::HTTPResponse.new
     text = "my text"
-    json = JSON.parse SLS::Lambda::HTTPResponse.new(200, text).to_json
+    res.body = text
+
+    json = JSON.parse res.to_json
     json["body"]?.should eq text
   end
 
   it "can contain a body as json" do
+    res = SLS::Lambda::HTTPResponse.new
     input = JSON.parse "{ \"foo\" : \"bar\" }"
-    json = JSON.parse SLS::Lambda::HTTPResponse.new(200, input).to_json
+    res.body = input
+
+    json = JSON.parse res.to_json
     json["body"]["foo"]?.should eq "bar"
   end
 
   it "can contain additional headers" do
-    response = SLS::Lambda::HTTPResponse.new(200, "body")
-    response.headers["Content-Type"] = "application/text"
-    json = JSON.parse response.to_json
+    res = SLS::Lambda::HTTPResponse.new
+    res.headers["Content-Type"] = "application/text"
+
+    json = JSON.parse res.to_json
     json["headers"]["Content-Type"]?.should eq "application/text"
   end
 
   it "can return a JSON::Any object" do
-    response = SLS::Lambda::HTTPResponse.new(200, "body")
-    response.headers["Content-Type"] = "application/text"
-    json = response.as_json
+    res = SLS::Lambda::HTTPResponse.new
+    res.headers["Content-Type"] = "application/text"
+    json = res.as_json
+
     json.should be_a(JSON::Any)
     json.as_h["headers"]["Content-Type"]?.should eq "application/text"
   end

--- a/spec/serverless/lambda/runtime_spec.cr
+++ b/spec/serverless/lambda/runtime_spec.cr
@@ -1,16 +1,25 @@
 require "spec"
 require "../../spec_helper"
 
-def mock_next_invocation(body : String)
-  WebMock.stub(:get, "http://localhost/2018-06-01/runtime/invocation/next")
-    .to_return(
-      status: 200,
-      body: body,
-      headers: {
-        "Lambda-Runtime-Aws-Request-Id" => "54321",
-        "Lambda-Runtime-Trace-Id" => "TRACE-ID", "Content-Type": "application/json",
-      },
-    )
+def mock_next_invocation(
+  body = "",
+  headers = {} of String => String,
+  url = "http://localhost/2018-06-01/runtime/invocation/next",
+  method = :get
+)
+  WebMock.stub(
+    method,
+    url
+  ).with(headers: headers).to_return(
+    status: 200,
+    body: body,
+    headers: {
+      "Lambda-Runtime-Aws-Request-Id" => "54321",
+      "Lambda-Runtime-Trace-Id" => "TRACE-ID", "Content-Type": "application/json",
+      "Lambda-Runtime-Invoked-Function-Arn" => "1234567890arn",
+      "Lambda-Runtime-Deadline-Ms" => "1000000",
+    },
+  )
 end
 
 describe SLS::Lambda::Runtime do
@@ -19,101 +28,41 @@ describe SLS::Lambda::Runtime do
 
   Spec.before_each do
     WebMock.reset
-    ENV["AWS_LAMBDA_RUNTIME_API"] = "localhost:80"
-    ENV["_HANDLER"] = "my_handler"
+    set_runtime_env_var
     io.clear
   end
 
-  it "can read the runtime API from the environment" do
+  it "can process a request" do
+    req_url = "http://my-host:12345/2018-06-01/runtime/invocation/next"
+    res_url = "http://my-host:12345/2018-06-01/runtime/invocation/54321/response"
     ENV["AWS_LAMBDA_RUNTIME_API"] = "my-host:12345"
-    runtime = SLS::Lambda::Runtime.new(backend, Log::Severity::Info)
-    runtime.host.should eq "my-host"
-    runtime.port.should eq 12345
-  end
 
-  it "should be able to register a handler" do
-    runtime = SLS::Lambda::Runtime.new(backend, Log::Severity::Info)
-    # handler = do |_input| JSON.parse SLS::Lambda::HTTPResponse.new(200).to_json end
-    runtime.register_handler("my_handler") do |_input|
-      JSON.parse(%q({ "foo" : "bar"}))
+    # The handler to get called by the runtime
+    proc = ->(ctx : SLS::Lambda::Context) do
+      ctx.res.body = {foo: "bar"}.to_json
     end
-    runtime.handlers["my_handler"].should_not be_nil
-  end
 
-  it "can run with an event" do
-    body = %Q({ "input" : { "test" : "test" }})
-    mock_next_invocation body
+    mock_next_invocation(
+      body: request_body,
+      headers: {"Host" => "my-host:12345"},
+      url: req_url
+    )
 
-    WebMock.stub(:post, "http://localhost/2018-06-01/runtime/invocation/54321/response").to_return do |request|
+    # Stub the final post request and ensure the
+    # request contains the proper body
+    WebMock.stub(:post, res_url).to_return do |request|
       req = JSON.parse request.body.to_s
-      req.as(JSON::Any)["foo"].as_s.should eq "bar"
+      body = JSON.parse req["body"].to_s
+      body["foo"].should eq "bar"
+
+      # Return 202 so the runtime doesn't throw an error
       HTTP::Client::Response.new(202)
     end
 
-    runtime = SLS::Lambda::Runtime.new(backend, Log::Severity::Info)
-    runtime.register_handler("my_handler") do
-      JSON.parse(%q({ "foo" : "bar" }))
-    end
-    runtime.process_handler
-  end
+    # Ensure the runtime only does 1 iteration
+    SLS::Lambda::Runtime.break_loop = true
 
-  it "can return text responses including header" do
-    body = %Q({ "body" : "This is my body", "headers" : { "foo": "bar" }, "path" : "/my-test-path", "httpMethod": "POST", "requestContext" : {}})
-
-    mock_next_invocation body
-
-    WebMock.stub(:post, "http://localhost/2018-06-01/runtime/invocation/54321/response").to_return do |request|
-      req = JSON.parse request.body.to_s
-      req.as(JSON::Any)["statusCode"].as_i.should eq 200
-      req.as(JSON::Any)["body"].as_s.should eq "text body"
-      req.as(JSON::Any)["headers"]["Content-Type"].as_s.should eq "application/text"
-
-      HTTP::Client::Response.new(202)
-    end
-
-    runtime = SLS::Lambda::Runtime.new(backend, Log::Severity::Info)
-    runtime.register_handler("my_handler") do
-      response = SLS::Lambda::HTTPResponse.new(200, "text body")
-      response.headers["Content-Type"] = "application/text"
-      JSON.parse response.to_json
-    end
-    runtime.process_handler
-  end
-
-  it "can handle exceptions" do
-    body = %Q({ "body" : "This is my body", "headers" : { "foo": "bar" }, "path" : "/my-test-path", "httpMethod": "POST", "requestContext" : {}})
-
-    mock_next_invocation body
-
-    WebMock.stub(:post, "http://localhost/2018-06-01/runtime/invocation/54321/error").to_return do |request|
-      req = JSON.parse request.body.to_s
-      req.as(JSON::Any)["statusCode"].as_i.should eq 500
-      req.as(JSON::Any)["body"].as_s.should eq "anything"
-      HTTP::Client::Response.new(202)
-    end
-
-    runtime = SLS::Lambda::Runtime.new(backend, Log::Severity::Info)
-    runtime.register_handler("my_handler") do
-      raise "anything"
-    end
-    runtime.process_handler
-  end
-
-  it "sets the environment x-ray trace id" do
-    body = %Q({ "body" : "This is my body", "headers" : { "foo": "bar" }, "path" : "/my-test-path", "httpMethod": "POST", "requestContext" : {}})
-
-    mock_next_invocation body
-
-    WebMock.stub(:post, "http://localhost/2018-06-01/runtime/invocation/54321/response").to_return do |_request|
-      HTTP::Client::Response.new(202)
-    end
-
-    runtime = SLS::Lambda::Runtime.new(backend, Log::Severity::Info)
-    runtime.register_handler("my_handler") do
-      JSON.parse "{}"
-    end
-    runtime.process_handler
-
-    ENV["_X_AMZN_TRACE_ID"].should eq "TRACE-ID"
+    # Run
+    SLS::Lambda::Runtime.run_handler(proc)
   end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -116,3 +116,12 @@ def request_body
   }
 END
 end
+
+def set_runtime_env_var
+  ENV["_HANDLER"] = "my_handler"
+  ENV[SLS::Lambda::Runtime::RUNTIME_API] = "localhost:80"
+  ENV[SLS::Lambda::Runtime::FUNCTION_VERSION] = "7.0"
+  ENV[SLS::Lambda::Runtime::FUNCTION_MEMORY_SIZE] = "1000"
+  ENV[SLS::Lambda::Runtime::LOG_GROUP_NAME] = "my_log_group"
+  ENV[SLS::Lambda::Runtime::LOG_STREAM_NAME] = "my_stream_group"
+end

--- a/src/serverless/ext/athena.cr
+++ b/src/serverless/ext/athena.cr
@@ -1,0 +1,10 @@
+module SLS::Ext
+  module Athena
+    def self.handler(ctx : SLS::Lambda::Context) : Nil
+      response = ADI.container.athena_routing_route_handler.handle ctx.request
+
+      ctx.res.body = response.content
+      ctx.res.status_code = response.status.code
+    end
+  end
+end

--- a/src/serverless/ext/lucky.cr
+++ b/src/serverless/ext/lucky.cr
@@ -1,0 +1,19 @@
+require "./middleware"
+
+module SLS::Ext
+  module Lucky
+    def self.run(ctx : SLS::Lambda::Context, caller : HTTP::Handler) : Nil
+      caller.call(ctx)
+    end
+
+    def self.handler(app_server : AppServer)
+      caller = Middleware.build_middleware(app_server.middleware)
+
+      proc = ->(ctx : SLS::Lambda::Context) do
+        run(ctx, caller)
+      end
+
+      SLS::Lambda::Runtime.run_handler(proc)
+    end
+  end
+end

--- a/src/serverless/ext/middleware.cr
+++ b/src/serverless/ext/middleware.cr
@@ -1,0 +1,10 @@
+module SLS::Ext
+  module Middleware
+    def self.build_middleware(handlers, last_handler : (Context ->)? = nil)
+      raise ArgumentError.new "You must specify at least one HTTP Handler." if handlers.empty?
+      0.upto(handlers.size - 2) { |i| handlers[i].next = handlers[i + 1] }
+      handlers.last.next = last_handler if last_handler
+      handlers.first
+    end
+  end
+end

--- a/src/serverless/lambda.cr
+++ b/src/serverless/lambda.cr
@@ -1,4 +1,4 @@
-require "./lambda/*"
+require "./lambda/runtime"
 
 module SLS::Lambda
   Log = ::Log

--- a/src/serverless/lambda/http_context.cr
+++ b/src/serverless/lambda/http_context.cr
@@ -1,25 +1,27 @@
-# require "json"
+require "http"
+require "json"
 
-# module SLS::Lambda
-#   class Context < HTTP::Server::Context
-#     getter function_name : String
-#     getter function_version : String
-#     getter memory_limit_in_mb : UInt32
-#     getter log_group_name : String
-#     getter log_stream_name : String
-#     getter aws_request_id : String
-#     getter invoked_function_arn : String
-#     getter deadline_ms : Int64
-#     getter identity : JSON::Any
-#     getter client_context : JSON::Any
+module SLS::Lambda
+  class Context < HTTP::Server::Context
+    getter function_name : String
+    getter function_version : String
+    getter memory_limit_in_mb : UInt32
+    getter log_group_name : String
+    getter log_stream_name : String
+    getter aws_request_id : String
+    getter invoked_function_arn : String
+    getter deadline_ms : Int64
+    getter identity : JSON::Any
+    getter client_context : JSON::Any
 
-#     def initialize(@function_name, @function_version, @memory_limit_in_mb,
-#                    @log_group_name, @log_stream_name, @aws_request_id, @invoked_function_arn,
-#                    @deadline_ms, @identity, @client_context)
-#     end
+    def initialize(@function_name, @function_version, @memory_limit_in_mb,
+                   @log_group_name, @log_stream_name, @aws_request_id, @invoked_function_arn,
+                   @deadline_ms, @identity, @client_context, request, response)
+      super(request, response)
+    end
 
-#     def get_remaining_time_in_millis
-#       @deadline_ms - Time.now.to_unix_ms
-#     end
-#   end
-# end
+    def get_remaining_time_in_millis
+      @deadline_ms - Time.now.to_unix_ms
+    end
+  end
+end

--- a/src/serverless/lambda/http_context.cr
+++ b/src/serverless/lambda/http_context.cr
@@ -3,11 +3,19 @@ require "json"
 
 module SLS::Lambda
   class Context < HTTP::Server::Context
+    # The name of the lambda function
     getter function_name : String
+
+    # The current function version
     getter function_version : String
+
+    # The memory limit currently allocated to this function in Megabytes
     getter memory_limit_in_mb : UInt32
+
     getter log_group_name : String
     getter log_stream_name : String
+
+    # The current request id from aws
     getter aws_request_id : String
     getter invoked_function_arn : String
     getter deadline_ms : Int64

--- a/src/serverless/lambda/http_context.cr
+++ b/src/serverless/lambda/http_context.cr
@@ -24,13 +24,16 @@ module SLS::Lambda
     getter identity : JSON::Any
     getter client_context : JSON::Any
 
+    getter host : String
+    getter port : String
+
     getter req : HTTPRequest
     getter res : HTTPResponse
 
     def initialize(@function_name, @function_version, @memory_limit_in_mb,
                    @log_group_name, @log_stream_name, @aws_request_id, @invoked_function_arn,
-                   @deadline_ms, @identity, @client_context, @req : HTTPRequest,
-                   @res : HTTPResponse)
+                   @deadline_ms, @identity, @client_context, @host, @port,
+                   @req : HTTPRequest, @res : HTTPResponse)
       super(@req, @res)
     end
 

--- a/src/serverless/lambda/http_context.cr
+++ b/src/serverless/lambda/http_context.cr
@@ -1,0 +1,25 @@
+# require "json"
+
+# module SLS::Lambda
+#   class Context < HTTP::Server::Context
+#     getter function_name : String
+#     getter function_version : String
+#     getter memory_limit_in_mb : UInt32
+#     getter log_group_name : String
+#     getter log_stream_name : String
+#     getter aws_request_id : String
+#     getter invoked_function_arn : String
+#     getter deadline_ms : Int64
+#     getter identity : JSON::Any
+#     getter client_context : JSON::Any
+
+#     def initialize(@function_name, @function_version, @memory_limit_in_mb,
+#                    @log_group_name, @log_stream_name, @aws_request_id, @invoked_function_arn,
+#                    @deadline_ms, @identity, @client_context)
+#     end
+
+#     def get_remaining_time_in_millis
+#       @deadline_ms - Time.now.to_unix_ms
+#     end
+#   end
+# end

--- a/src/serverless/lambda/http_context.cr
+++ b/src/serverless/lambda/http_context.cr
@@ -1,5 +1,7 @@
 require "http"
 require "json"
+require "./http_request"
+require "./http_response"
 
 module SLS::Lambda
   class Context < HTTP::Server::Context
@@ -22,10 +24,14 @@ module SLS::Lambda
     getter identity : JSON::Any
     getter client_context : JSON::Any
 
+    getter req : HTTPRequest
+    getter res : HTTPResponse
+
     def initialize(@function_name, @function_version, @memory_limit_in_mb,
                    @log_group_name, @log_stream_name, @aws_request_id, @invoked_function_arn,
-                   @deadline_ms, @identity, @client_context, request, response)
-      super(request, response)
+                   @deadline_ms, @identity, @client_context, @req : HTTPRequest,
+                   @res : HTTPResponse)
+      super(@req, @res)
     end
 
     def get_remaining_time_in_millis

--- a/src/serverless/lambda/http_response.cr
+++ b/src/serverless/lambda/http_response.cr
@@ -5,9 +5,9 @@ module SLS::Lambda
   class HTTPResponse < HTTP::Server::Response
     property body : String | JSON::Any | Nil
     getter headers : HTTP::Headers
-    getter status_code
+    property status_code : Int32?
 
-    def initialize(@status_code = 200, @body = nil)
+    def initialize(@status_code = nil, @body = nil)
       @headers = HTTP::Headers.new
       super(IO::Memory.new)
     end
@@ -16,7 +16,7 @@ module SLS::Lambda
     def as_json : JSON::Any
       json = Hash(String, JSON::Any).new
 
-      json["statusCode"] = JSON::Any.new status_code.to_i64
+      json["statusCode"] = JSON::Any.new (code = status_code) ? code.to_i64 : 500.to_i64
 
       if !body.nil?
         json["body"] = (body.class == JSON::Any ? body.as(JSON::Any) : JSON::Any.new(body.as(String)))

--- a/src/serverless/lambda/http_response.cr
+++ b/src/serverless/lambda/http_response.cr
@@ -6,10 +6,12 @@ module SLS::Lambda
     property body : String | JSON::Any | Nil
     getter headers : HTTP::Headers
     property status_code : Int32?
+    getter _io : IO::Memory
 
     def initialize(@status_code = nil, @body = nil)
       @headers = HTTP::Headers.new
-      super(IO::Memory.new)
+      @_io = IO::Memory.new
+      super(_io)
     end
 
     # Returns a `JSON::Any` object for passing on to AWS

--- a/src/serverless/lambda/http_response.cr
+++ b/src/serverless/lambda/http_response.cr
@@ -6,12 +6,10 @@ module SLS::Lambda
     property body : String | JSON::Any | Nil
     getter headers : HTTP::Headers
     property status_code : Int32?
-    getter _io : IO::Memory
 
-    def initialize(@status_code = nil, @body = nil)
+    def initialize(io : IO::Memory)
       @headers = HTTP::Headers.new
-      @_io = IO::Memory.new
-      super(_io)
+      super(io)
     end
 
     # Returns a `JSON::Any` object for passing on to AWS

--- a/src/serverless/lambda/runtime.cr
+++ b/src/serverless/lambda/runtime.cr
@@ -2,64 +2,49 @@ require "http/client"
 require "json"
 
 module SLS::Lambda
-  struct Context
-    getter function_name : String
-    getter function_version : String
-    getter memory_limit_in_mb : UInt32
-    getter log_group_name : String
-    getter log_stream_name : String
-    getter aws_request_id : String
-    getter invoked_function_arn : String
-    getter deadline_ms : Int64
-    getter identity : JSON::Any
-    getter client_context : JSON::Any
+  class Runtime
+    def self.run_handler(handler : Proc(JSON::Any, Context, Object))
+      function_name = ENV["AWS_LAMBDA_RUNTIME_API"]
+      function_version = ENV["AWS_LAMBDA_FUNCTION_VERSION"]
+      memory_limit_in_mb = UInt32.new(ENV["AWS_LAMBDA_FUNCTION_MEMORY_SIZE"])
+      log_group_name = ENV["AWS_LAMBDA_LOG_GROUP_NAME"]
+      log_stream_name = ENV["AWS_LAMBDA_LOG_STREAM_NAME"]
+      host, port = ENV["AWS_LAMBDA_RUNTIME_API"].split(':')
 
-    def initialize(@function_name, @function_version, @memory_limit_in_mb,
-                   @log_group_name, @log_stream_name, @aws_request_id, @invoked_function_arn,
-                   @deadline_ms, @identity, @client_context)
-    end
+      client = HTTP::Client.new(host, port)
 
-    def get_remaining_time_in_millis
-      @deadline_ms - Time.now.to_unix_ms
-    end
-  end
+      while true
+        res = client.get("/2018-06-01/runtime/invocation/next")
+        if res.status_code != 200
+          raise "Unexpected response when invoking: #{res.status_code}"
+        end
 
-  def self.run_handler(handler : Proc(JSON::Any, Context, Object))
-    function_name = ENV["AWS_LAMBDA_RUNTIME_API"]
-    function_version = ENV["AWS_LAMBDA_FUNCTION_VERSION"]
-    memory_limit_in_mb = UInt32.new(ENV["AWS_LAMBDA_FUNCTION_MEMORY_SIZE"])
-    log_group_name = ENV["AWS_LAMBDA_LOG_GROUP_NAME"]
-    log_stream_name = ENV["AWS_LAMBDA_LOG_STREAM_NAME"]
-    host, port = ENV["AWS_LAMBDA_RUNTIME_API"].split(':')
+        ENV["_X_AMZN_TRACE_ID"] = res.headers["Lambda-Runtime-Trace-Id"]? || ""
 
-    client = HTTP::Client.new(host, port)
+        context = Context.new(
+          function_name,
+          function_version,
+          memory_limit_in_mb,
+          log_group_name,
+          log_stream_name,
+          res.headers["Lambda-Runtime-Aws-Request-Id"],
+          res.headers["Lambda-Runtime-Invoked-Function-Arn"],
+          Int64.new(res.headers["Lambda-Runtime-Deadline-Ms"]),
+          JSON.parse(res.headers["Lambda-Runtime-Cognito-Identity"]? || "null"),
+          JSON.parse(res.headers["Lambda-Runtime-Client-Context"]? || "null"),
+          HTTPRequest.new(JSON.parse(res.body)),
+          HTTPResponse.new
+        )
 
-    while true
-      res = client.get("/2018-06-01/runtime/invocation/next")
-      if res.status_code != 200
-        raise "Unexpected response when invoking: #{res.status_code}"
-      end
+        result = handler.call(context)
 
-      ENV["_X_AMZN_TRACE_ID"] = res.headers["Lambda-Runtime-Trace-Id"]? || ""
-
-      context = Context.new(
-        function_name,
-        function_version,
-        memory_limit_in_mb,
-        log_group_name,
-        log_stream_name,
-        res.headers["Lambda-Runtime-Aws-Request-Id"],
-        res.headers["Lambda-Runtime-Invoked-Function-Arn"],
-        Int64.new(res.headers["Lambda-Runtime-Deadline-Ms"]),
-        JSON.parse(res.headers["Lambda-Runtime-Cognito-Identity"]? || "null"),
-        JSON.parse(res.headers["Lambda-Runtime-Client-Context"]? || "null"),
-      )
-
-      result = handler.call(JSON.parse(res.body), context)
-
-      res = client.post("/2018-06-01/runtime/invocation/#{context.aws_request_id}/response", body: result.to_json)
-      if res.status_code != 202
-        raise "Unexpected response when responding: #{res.status_code}"
+        res = client.post(
+          "/2018-06-01/runtime/invocation/#{context.aws_request_id}/response",
+          body: result.to_json
+        )
+        if res.status_code != 202
+          raise "Unexpected response when responding: #{res.status_code}"
+        end
       end
     end
   end

--- a/src/serverless/lambda/runtime.cr
+++ b/src/serverless/lambda/runtime.cr
@@ -3,45 +3,74 @@ require "json"
 
 module SLS::Lambda
   class Runtime
-    def self.run_handler(handler : Proc(Context, JSON::Any))
-      function_name = ENV["AWS_LAMBDA_RUNTIME_API"]
-      function_version = ENV["AWS_LAMBDA_FUNCTION_VERSION"]
-      memory_limit_in_mb = UInt32.new(ENV["AWS_LAMBDA_FUNCTION_MEMORY_SIZE"])
-      log_group_name = ENV["AWS_LAMBDA_LOG_GROUP_NAME"]
-      log_stream_name = ENV["AWS_LAMBDA_LOG_STREAM_NAME"]
-      host, port = ENV["AWS_LAMBDA_RUNTIME_API"].split(':')
+    # AWS Lambda Environment Variables
+    RUNTIME_API          = "AWS_LAMBDA_RUNTIME_API"
+    FUNCTION_VERSION     = "AWS_LAMBDA_FUNCTION_VERSION"
+    FUNCTION_MEMORY_SIZE = "AWS_LAMBDA_FUNCTION_MEMORY_SIZE"
+    LOG_GROUP_NAME       = "AWS_LAMBDA_LOG_GROUP_NAME"
+    LOG_STREAM_NAME      = "AWS_LAMBDA_LOG_STREAM_NAME"
 
+    # AWS Lambda request variables
+    BASE_URL                = "/2018-06-01/runtime/invocation"
+    NEXT_URL                = BASE_URL + "/next"
+    TRACE_ID                = "_X_AMZN_TRACE_ID"
+    TRACE_ID_HEADER         = "Lambda-Runtime-Trace-Id"
+    REQUEST_ID_HEADER       = "Lambda-Runtime-Aws-Request-Id"
+    FUNCTION_ARN_HEADER     = "Lambda-Runtime-Invoked-Function-Arn"
+    DEADLINE_HEADER         = "Lambda-Runtime-Deadline-Ms"
+    COGNITO_IDENTITY_HEADER = "Lambda-Runtime-Cognito-Identity"
+    CLIENT_CONTEXT_HEADER   = "Lambda-Runtime-Client-Context"
+
+    def self.run_handler(handler : Proc(Context, JSON::Any))
+      function_name = ENV[RUNTIME_API]
+      function_version = ENV[FUNCTION_VERSION]
+      memory_limit_in_mb = UInt32.new(ENV[FUNCTION_MEMORY_SIZE])
+      log_group_name = ENV[LOG_GROUP_NAME]
+      log_stream_name = ENV[LOG_STREAM_NAME]
+      host, port = ENV[RUNTIME_API].split(':')
+
+      # Instaniate the http client that we will use for the
+      # lifetime of the function.
       client = HTTP::Client.new(host, port)
 
       while true
-        res = client.get("/2018-06-01/runtime/invocation/next")
+        # Fetch the request of AWS Lambda
+        res = client.get(NEXT_URL)
+
+        # Ensure the request is a 200
         if res.status_code != 200
           raise "Unexpected response when invoking: #{res.status_code}"
         end
 
-        ENV["_X_AMZN_TRACE_ID"] = res.headers["Lambda-Runtime-Trace-Id"]? || ""
+        # Set the trace ID
+        ENV[TRACE_ID] = res.headers[TRACE_ID_HEADER]? || ""
 
+        # Create a new context object to pass into handler
         context = Context.new(
           function_name,
           function_version,
           memory_limit_in_mb,
           log_group_name,
           log_stream_name,
-          res.headers["Lambda-Runtime-Aws-Request-Id"],
-          res.headers["Lambda-Runtime-Invoked-Function-Arn"],
-          Int64.new(res.headers["Lambda-Runtime-Deadline-Ms"]),
-          JSON.parse(res.headers["Lambda-Runtime-Cognito-Identity"]? || "null"),
-          JSON.parse(res.headers["Lambda-Runtime-Client-Context"]? || "null"),
+          res.headers[REQUEST_ID_HEADER],
+          res.headers[FUNCTION_ARN_HEADER],
+          Int64.new(res.headers[DEADLINE_HEADER]),
+          JSON.parse(res.headers[COGNITO_IDENTITY_HEADER]? || "null"),
+          JSON.parse(res.headers[CLIENT_CONTEXT_HEADER]? || "null"),
           HTTPRequest.new(JSON.parse(res.body)),
           HTTPResponse.new
         )
 
+        # Invoke the handler
         result = handler.call(context)
 
+        # Return the response to AWS Lambda
         res = client.post(
-          "/2018-06-01/runtime/invocation/#{context.aws_request_id}/response",
+          BASE_URL + "/#{context.aws_request_id}/response",
           body: result.to_json
         )
+
+        # Ensure AWS Lambda recieved tbe response
         if res.status_code != 202
           raise "Unexpected response when responding: #{res.status_code}"
         end

--- a/src/serverless/lambda/runtime.cr
+++ b/src/serverless/lambda/runtime.cr
@@ -34,6 +34,7 @@ module SLS::Lambda
       # lifetime of the function.
       client = HTTP::Client.new(host, port)
 
+      # ameba:disable Style/WhileTrue
       while true
         # Fetch the request of AWS Lambda
         res = client.get(NEXT_URL)
@@ -76,6 +77,7 @@ module SLS::Lambda
           raise "Unexpected response when responding: #{res.status_code}"
         end
       end
+      # ameba:enable Style/WhileTrue
     end
   end
 end

--- a/src/serverless/lambda/runtime.cr
+++ b/src/serverless/lambda/runtime.cr
@@ -46,8 +46,6 @@ module SLS::Lambda
         # Set the trace ID
         ENV[TRACE_ID] = res.headers[TRACE_ID_HEADER]? || ""
 
-        io = IO::Memory.new
-
         # Create a new context object to pass into handler
         context = Context.new(
           function_name,
@@ -61,7 +59,7 @@ module SLS::Lambda
           JSON.parse(res.headers[COGNITO_IDENTITY_HEADER]? || "null"),
           JSON.parse(res.headers[CLIENT_CONTEXT_HEADER]? || "null"),
           SLS::Lambda::HTTPRequest.new(JSON.parse(res.body)),
-          SLS::Lambda::HTTPResponse.new(io)
+          SLS::Lambda::HTTPResponse.new
         )
 
         # Invoke the handler

--- a/src/serverless/lambda/runtime.cr
+++ b/src/serverless/lambda/runtime.cr
@@ -1,88 +1,43 @@
-require "http"
-require "log"
-require "./http_request"
-require "./http_response"
+require "http/client"
+require "json"
 
-module SLS
-  module Lambda
-    class Runtime
-      HANDLER           = "_HANDLER"
-      TRACE_ID          = "_X_AMZN_TRACE_ID"
-      TRACE_ID_HEADER   = "Lambda-Runtime-Trace-Id"
-      REQUEST_ID_HEADER = "Lambda-Runtime-Aws-Request-Id"
-      RUNTIME_BASE_URL  = "/2018-06-01/runtime/invocation"
-      RUNTIME_API_URL   = RUNTIME_BASE_URL + "/next"
+module SLS::Lambda
+  def self.run_handler(handler : Proc(JSON::Any, Context, Object))
+    function_name = ENV["AWS_LAMBDA_RUNTIME_API"]
+    function_version = ENV["AWS_LAMBDA_FUNCTION_VERSION"]
+    memory_limit_in_mb = UInt32.new(ENV["AWS_LAMBDA_FUNCTION_MEMORY_SIZE"])
+    log_group_name = ENV["AWS_LAMBDA_LOG_GROUP_NAME"]
+    log_stream_name = ENV["AWS_LAMBDA_LOG_STREAM_NAME"]
+    host, port = ENV["AWS_LAMBDA_RUNTIME_API"].split(':')
 
-      getter host : String
-      getter port : Int16
-      getter handlers : Hash(String, (JSON::Any -> JSON::Any)) = Hash(String, (JSON::Any -> JSON::Any)).new
-      getter logger : ::Log
+    client = HTTP::Client.new(host, port)
 
-      def initialize(backend : ::Log::IOBackend? = nil, level = ::Log::Severity::Debug)
-        api = ENV["AWS_LAMBDA_RUNTIME_API"].split(":", 2)
-
-        @host = api[0]
-        @port = api[1].to_i16
-
-        # Format logs specifically for Lambda
-        backend ||= ::Log::IOBackend.new(formatter: Lambda.formatter)
-        Lambda::Log.setup do |c|
-          c.bind "serverless.lambda", level, backend
-        end
-        @logger = Lambda::Log.for("serverless.lambda")
+    while true
+      res = client.get("/2018-06-01/runtime/invocation/next")
+      if res.status_code != 200
+        raise "Unexpected response when invoking: #{res.status_code}"
       end
 
-      # Associate the block/proc to the function name
-      def register_handler(name : String, &handler : JSON::Any -> JSON::Any)
-        self.handlers[name] = handler
-      end
+      ENV["_X_AMZN_TRACE_ID"] = res.headers["Lambda-Runtime-Trace-Id"]? || ""
 
-      def run
-        loop do
-          process_handler
-        end
-      end
+      context = Context.new(
+        function_name,
+        function_version,
+        memory_limit_in_mb,
+        log_group_name,
+        log_stream_name,
+        res.headers["Lambda-Runtime-Aws-Request-Id"],
+        res.headers["Lambda-Runtime-Invoked-Function-Arn"],
+        Int64.new(res.headers["Lambda-Runtime-Deadline-Ms"]),
+        JSON.parse(res.headers["Lambda-Runtime-Cognito-Identity"]? || "null"),
+        JSON.parse(res.headers["Lambda-Runtime-Client-Context"]? || "null"),
+      )
 
-      def process_handler
-        handler_name = ENV[HANDLER]
+      result = handler.call(JSON.parse(res.body), context)
 
-        if handlers.has_key?(handler_name)
-          _process_request handlers[handler_name]
-        else
-          logger.error {
-            "unknown handler: #{handler_name}, available handlers: #{handlers.keys.join(", ")}"
-          }
-        end
-      end
-
-      def _process_request(proc : Proc(JSON::Any, JSON::Any))
-        client = HTTP::Client.new(host: @host, port: @port)
-
-        begin
-          response = client.get RUNTIME_API_URL
-          ENV[TRACE_ID] = response.headers[TRACE_ID_HEADER] || ""
-
-          aws_request_id = response.headers[REQUEST_ID_HEADER]
-          base_url = RUNTIME_BASE_URL + "/#{aws_request_id}"
-
-          input = JSON.parse response.body
-
-          body = proc.call input
-
-          logger.info { "preparing body #{body}" }
-          response = client.post("#{base_url}/response", body: body.to_json)
-          logger.debug { "response invocation response #{response.status_code} #{response.body}" }
-        rescue ex : Exception
-          body = %Q({ "statusCode": 500, "body" : "#{ex.message}" })
-          response = client.post("#{base_url}/error", body: body)
-
-          Log.error {
-            "response error invocation response from exception " \
-            "#{ex.message} #{response.status_code} #{response.body}"
-          }
-        ensure
-          client.close
-        end
+      res = client.post("/2018-06-01/runtime/invocation/#{context.aws_request_id}/response", body: result.to_json)
+      if res.status_code != 202
+        raise "Unexpected response when responding: #{res.status_code}"
       end
     end
   end

--- a/src/serverless/lambda/runtime.cr
+++ b/src/serverless/lambda/runtime.cr
@@ -2,6 +2,28 @@ require "http/client"
 require "json"
 
 module SLS::Lambda
+  struct Context
+    getter function_name : String
+    getter function_version : String
+    getter memory_limit_in_mb : UInt32
+    getter log_group_name : String
+    getter log_stream_name : String
+    getter aws_request_id : String
+    getter invoked_function_arn : String
+    getter deadline_ms : Int64
+    getter identity : JSON::Any
+    getter client_context : JSON::Any
+
+    def initialize(@function_name, @function_version, @memory_limit_in_mb,
+                   @log_group_name, @log_stream_name, @aws_request_id, @invoked_function_arn,
+                   @deadline_ms, @identity, @client_context)
+    end
+
+    def get_remaining_time_in_millis
+      @deadline_ms - Time.now.to_unix_ms
+    end
+  end
+
   def self.run_handler(handler : Proc(JSON::Any, Context, Object))
     function_name = ENV["AWS_LAMBDA_RUNTIME_API"]
     function_version = ENV["AWS_LAMBDA_FUNCTION_VERSION"]

--- a/src/serverless/lambda/runtime.cr
+++ b/src/serverless/lambda/runtime.cr
@@ -58,7 +58,7 @@ module SLS::Lambda
           JSON.parse(res.headers[COGNITO_IDENTITY_HEADER]? || "null"),
           JSON.parse(res.headers[CLIENT_CONTEXT_HEADER]? || "null"),
           HTTPRequest.new(JSON.parse(res.body)),
-          HTTPResponse.new(io)
+          HTTPResponse.new
         )
 
         # Invoke the handler

--- a/src/serverless/lambda/runtime.cr
+++ b/src/serverless/lambda/runtime.cr
@@ -3,7 +3,7 @@ require "json"
 
 module SLS::Lambda
   class Runtime
-    def self.run_handler(handler : Proc(JSON::Any, Context, Object))
+    def self.run_handler(handler : Proc(Context, JSON::Any))
       function_name = ENV["AWS_LAMBDA_RUNTIME_API"]
       function_version = ENV["AWS_LAMBDA_FUNCTION_VERSION"]
       memory_limit_in_mb = UInt32.new(ENV["AWS_LAMBDA_FUNCTION_MEMORY_SIZE"])

--- a/src/serverless/lambda/runtime.cr
+++ b/src/serverless/lambda/runtime.cr
@@ -58,16 +58,19 @@ module SLS::Lambda
           JSON.parse(res.headers[COGNITO_IDENTITY_HEADER]? || "null"),
           JSON.parse(res.headers[CLIENT_CONTEXT_HEADER]? || "null"),
           HTTPRequest.new(JSON.parse(res.body)),
-          HTTPResponse.new
+          HTTPResponse.new(io)
         )
 
         # Invoke the handler
-        result = handler.call(context)
+        handler.call(context)
+
+        pp "RESPONSE"
+        pp context.response._io.to_s.split("\n").last
 
         # Return the response to AWS Lambda
         res = client.post(
           BASE_URL + "/#{context.aws_request_id}/response",
-          body: result.to_json
+          body: context.response._io.to_s.split("\n").last
         )
 
         # Ensure AWS Lambda recieved tbe response


### PR DESCRIPTION
Crambda had a really clean runtime compared to crystal-aws-lambda along with some extra information. The two shards have essentially been combined. 

This also adds an ext folder to support frameworks out-of-the-box. 

Current supported frameworks:
- Athena
- Lucky

